### PR TITLE
Add example : linux raspberry pi

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,42 @@
+name: Test all targets
+
+on: [push, pull_request]
+
+permissions:
+  contents: write
+
+jobs:
+  quick-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          override: true
+      - name: Check Type
+        run: cargo fmt -- --check
+      - name: Check Clippy
+        run: cargo clippy -- -Dwarnings
+      - name: Run internal tests
+        run: cargo test --verbose -- --nocapture
+      - name: Build
+        run: cargo build
+
+  build:
+    needs: quick-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          override: true
+      - name: Build docs
+        run: cargo doc
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ panic-rtt-core = {version="0.1.0", optional=true}
 
 [dev-dependencies]
 embedded-hal-mock = "0.7.1"
+linux-embedded-hal = "0.3.2"
 
 [features]
 default = []

--- a/examples/raspberrypi.rs
+++ b/examples/raspberrypi.rs
@@ -1,0 +1,44 @@
+use icm20689::{AccelRange, Builder, GyroRange};
+use linux_embedded_hal::spidev::{self, SpidevOptions};
+use linux_embedded_hal::sysfs_gpio::Direction;
+use linux_embedded_hal::{Delay, Pin, Spidev};
+
+fn main() {
+    let mut spi = Spidev::open("/dev/spidev1.0").expect("SPI device");
+    let options = SpidevOptions::new()
+        .bits_per_word(8)
+        .max_speed_hz(10_000_000)
+        .mode(spidev::SpiModeFlags::SPI_MODE_0)
+        .build();
+    spi.configure(&options).expect("SPI configuration");
+
+    let cs = Pin::new(16); // CS2 pin
+    cs.export().expect("cs export");
+    while !cs.is_exported() {}
+    cs.set_direction(Direction::Out).expect("CS Direction");
+    cs.set_value(1).expect("CS Value set to 1");
+
+    //initialize the sensor thourgh spi
+    let mut imu = Builder::new_spi(spi, cs);
+    // let mut imu_i2c = Builder::new_i2c(i2c, adress);
+
+    //you need to implement an delay_source
+    let mut delay_source = Delay {};
+
+    println!(
+        "Check device, device support = {}",
+        imu.check_identity(&mut delay_source).unwrap()
+    );
+
+    imu.setup(&mut delay_source).expect("error setup");
+
+    imu.set_accel_range(AccelRange::Range_2g)
+        .expect("error set_accel");
+    imu.set_gyro_range(GyroRange::Range_250dps)
+        .expect("error set_gyro");
+
+    let accel = imu.get_scaled_accel().unwrap();
+    let gyro = imu.get_scaled_gyro().unwrap();
+    println!("Accelerometer: {:?}", accel);
+    println!("Gyroscope: {:?}", gyro);
+}

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -26,7 +26,7 @@ where
     const DIR_READ: u8 = 0x80; // same as 1<<7
 
     pub fn new(spi: SPI, csn: CSN) -> Self {
-        let mut inst = Self { spi: spi, csn: csn };
+        let mut inst = Self { spi, csn };
         //ensure that the device is initially deselected
         let _ = inst.csn.set_high();
         inst

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ where
         Self {
             si: sensor_interface,
             gyro_scale: 0.0,
-            accel_scale: 0.0
+            accel_scale: 0.0,
         }
     }
 
@@ -239,7 +239,6 @@ where
             self.gyro_scale * (raw_gyro[2] as f32),
         ])
     }
-
 }
 
 /// Common registers
@@ -271,7 +270,7 @@ const ICM20689_WAI: u8 = 0x98;
 
 #[repr(u8)]
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 /// The gyroscope has a programmable full-scale range of ±250, ±500, ±1000, or ±2000 degrees/sec.
 pub enum GyroRange {
     /// ±250
@@ -281,6 +280,7 @@ pub enum GyroRange {
     /// ±1000
     Range_1000dps = 0b10,
     /// ±2000
+    #[default]
     Range_2000dps = 0b11,
 }
 
@@ -288,13 +288,6 @@ pub enum GyroRange {
 // 01= ±500dps
 // 10 = ±1000dps
 // 11 = ±2000dps
-
-impl Default for GyroRange {
-    fn default() -> Self {
-        GyroRange::Range_2000dps
-    }
-}
-
 
 impl GyroRange {
     /// convert degrees into radians
@@ -319,7 +312,7 @@ impl GyroRange {
 
 #[repr(u8)]
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 /// The accelerometer has a user-programmable accelerometer full-scale range
 /// of ±2g, ±4g, ±8g, and ±16g.
 /// (g is gravitational acceleration: 9.82 m/s^2)
@@ -330,15 +323,10 @@ pub enum AccelRange {
     /// ±4g
     Range_4g = 0b01,
     /// ±8g
+    #[default]
     Range_8g = 0b10,
     /// ±16g
     Range_16g = 0b11,
-}
-
-impl Default for AccelRange {
-    fn default() -> Self {
-        AccelRange::Range_8g
-    }
 }
 
 impl AccelRange {


### PR DESCRIPTION
I was having something difficult on how to use the library,
found some piece of codes from other projects like [pixracer_bsp](https://github.com/tstellanova/pixracer_bsp) and [Xpilot,](https://github.com/gqf2008/Xpilot)
and how to setup a spi like here: [spi-epaper-example](https://github.com/wezm/linux-conf-au-2019-epaper-badge/blob/32391fba0d7393b3c517bc9ef6679d131a7e0625/src/hardware.rs#L4)

Just the part of provide "delay_source" isn't totally clear, I guess it's because it's a HAL lib, so you can provide delay source from linux/stm/esp/other_hw.

```
use linux_embedded_hal::{Delay, Pin, Spidev};
   //you need to implement an delay_source
    let mut delay_source = Delay {};

```    
Maybe we can add this delay_source on the Builder? So isn't necessary to provide it for every function call.


Final result:
![image](https://user-images.githubusercontent.com/80598030/234682085-fea62f4e-3237-40cc-a1ec-f274bfd6e799.png)
