### PR TITLE
Update embedded hal to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,12 @@ keywords = [
 readme = "README.md"
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = "1.0.0"
 cortex-m = "0.6.2"
 panic-rtt-core = {version="0.1.0", optional=true}
 
 [dev-dependencies]
-embedded-hal-mock = "0.7.1"
+embedded-hal-mock = "0.10.0"
 
 [features]
 default = []

--- a/src/interface/i2c.rs
+++ b/src/interface/i2c.rs
@@ -12,9 +12,7 @@ pub struct I2cInterface<I2C> {
 
 impl<I2C, CommE> I2cInterface<I2C>
 where
-    I2C: hal::blocking::i2c::Read<Error = CommE>
-        + hal::blocking::i2c::Write<Error = CommE>
-        + hal::blocking::i2c::WriteRead<Error = CommE>,
+    I2C: hal::i2c::I2c<Error = CommE>,
 {
     pub fn new(i2c: I2C, address: u8) -> Self {
         Self {
@@ -26,9 +24,7 @@ where
 
 impl<I2C, CommE> SensorInterface for I2cInterface<I2C>
 where
-    I2C: hal::blocking::i2c::Read<Error = CommE>
-        + hal::blocking::i2c::Write<Error = CommE>
-        + hal::blocking::i2c::WriteRead<Error = CommE>,
+    I2C: hal::i2c::I2c<Error = CommE>,
 {
     type InterfaceError = Error<CommE, ()>;
 

--- a/src/interface/spi.rs
+++ b/src/interface/spi.rs
@@ -1,5 +1,5 @@
 use embedded_hal as hal;
-use hal::digital::v2::OutputPin;
+use hal::digital::OutputPin;
 
 use super::SensorInterface;
 use crate::Error;
@@ -18,8 +18,7 @@ pub struct SpiInterface<SPI, CSN> {
 
 impl<SPI, CSN, CommE, PinE> SpiInterface<SPI, CSN>
 where
-    SPI: hal::blocking::spi::Write<u8, Error = CommE>
-        + hal::blocking::spi::Transfer<u8, Error = CommE>,
+    SPI: hal::spi::SpiDevice<u8, Error = CommE>,
     CSN: OutputPin<Error = PinE>,
 {
     /// Combined with register address for reading single byte register
@@ -40,7 +39,7 @@ where
     fn read_block(&mut self, reg: u8, buffer: &mut [u8]) -> Result<(), Error<CommE, PinE>> {
         buffer[0] = reg | Self::DIR_READ;
         self.csn.set_low().map_err(Error::Pin)?;
-        let rc = self.spi.transfer(buffer);
+        let rc = self.spi.read(buffer);
         self.csn.set_high().map_err(Error::Pin)?;
         rc.map_err(Error::Comm)?;
 
@@ -62,8 +61,7 @@ where
 
 impl<SPI, CSN, CommE, PinE> SensorInterface for SpiInterface<SPI, CSN>
 where
-    SPI: hal::blocking::spi::Write<u8, Error = CommE>
-        + hal::blocking::spi::Transfer<u8, Error = CommE>,
+    SPI: hal::spi::SpiDevice<u8, Error = CommE>,
     CSN: OutputPin<Error = PinE>,
 {
     type InterfaceError = Error<CommE, PinE>;


### PR DESCRIPTION
Updates embedded HAL to v1.0.0 to allow programs that use this as a library to use GPIO pins through cdev instead of the deprecated-and-removed sysfs method.